### PR TITLE
Level range auto number

### DIFF
--- a/dist/docsify-autoHeaders.js
+++ b/dist/docsify-autoHeaders.js
@@ -164,6 +164,7 @@ function autoHeaders(hook, vm) {
 		}
 		const commentRegex = new RegExp(
 			'<!--\\s*autoHeader\\s*:\\s*(([\\w\\d]*' + separator + '?)+)\\s*-->');
+		getHeadingNumber = null;
 		for (const line of content.split("\n")) {
 			if (!line.startsWith("<!--")) {
 				break

--- a/dist/docsify-autoHeaders.js
+++ b/dist/docsify-autoHeaders.js
@@ -10,30 +10,25 @@
 //
 'use strict';
 
-
-
 //
 // MARK: - default values
 //
 const autoHeaderOptions = {
-	separator:	'decimal',
-	custom:		'.',
-	levels:		6,
-	scope:		'#main',
-	debug:		false
+	separator: 'decimal',
+	custom: '.',
+	levels: 6,
+	scope: '#main',
+	debug: false
 }
-
-
 
 //
 // MARK: - get the index.html options
 //
-function getAutoHeadersOptions( autoHeaderOptions ) {
-
+function getAutoHeadersOptions(autoHeaderOptions) {
 	// check for empty config
-	if(
-		!autoHeaderOptions.separator	||
-		!autoHeaderOptions.levels		||
+	if (
+		!autoHeaderOptions.separator ||
+		!autoHeaderOptions.levels ||
 		!autoHeaderOptions.scope
 	) {
 		return console.error(
@@ -50,24 +45,19 @@ function getAutoHeadersOptions( autoHeaderOptions ) {
 	);
 
 	// output the correct from words
-	switch( autoHeaderOptions.separator ) {
-
-		case 'decimal'	:
+	switch (autoHeaderOptions.separator) {
+		case 'decimal':
 			separator = '.';
 			break;
-
-		case 'dash'		:
+		case 'dash':
 			separator = '-';
 			break;
-
-		case 'bracket'	:
+		case 'bracket':
 			separator = ')';
 			break;
-
-		case 'other'	:
+		case 'other':
 			separator = separator;
 			break;
-
 		default:
 			return;
 	}
@@ -77,16 +67,16 @@ function getAutoHeadersOptions( autoHeaderOptions ) {
 		autoHeaderOptions.levels ?
 			autoHeaderOptions.levels : 6
 	);
-	if (typeof levels === "string"){
+	if (typeof levels === "string") {
 		levels = parseInt(levels)
 	}
-	if (typeof levels === "number" ){
+	if (typeof levels === "number") {
 		levels = {
 			start: 1,
 			finish: levels
 		}
 	}
-	else if (typeof levels === "object" ) {
+	else if (typeof levels === "object") {
 		if (typeof levels.start === "string") {
 			levels.start = parseInt(levels.start)
 		}
@@ -114,17 +104,15 @@ function getAutoHeadersOptions( autoHeaderOptions ) {
 	];
 }
 
-
-
 //
 // MARK: - main function
 //
-function autoHeaders( hook, vm ) {
+function autoHeaders(hook, vm) {
 
 	//
 	// MARK: - safety
 	//
-	if( getAutoHeadersOptions( autoHeaderOptions ) === undefined ) {
+	if (getAutoHeadersOptions(autoHeaderOptions) === undefined) {
 		return;
 	}
 
@@ -132,58 +120,52 @@ function autoHeaders( hook, vm ) {
 	//
 	// MARK: - variables
 	//
-
 	let getHeadingNumber = null;
 
 	// get the options variables
-	const getAutoHeadersOptionsArray = getAutoHeadersOptions(
-		autoHeaderOptions
-	),
-	// create new variables
-	optionsSeparator = getAutoHeadersOptionsArray[ 0 ],
-	optionsLevel     = getAutoHeadersOptionsArray[ 1 ],
-	optionsScope     = getAutoHeadersOptionsArray[ 2 ],
-	optionsDebug     = getAutoHeadersOptionsArray[ 3 ],
+	const getAutoHeadersOptionsArray = getAutoHeadersOptions(autoHeaderOptions),
+		optionsSeparator = getAutoHeadersOptionsArray[0],
+		optionsLevel = getAutoHeadersOptionsArray[1],
+		optionsScope = getAutoHeadersOptionsArray[2],
+		optionsDebug = getAutoHeadersOptionsArray[3],
 
-	// get the heading range from options
-	setHeadingRange = ( headingInputValue ) => {
-		// the headingInputValue is an object with 'start' and 'finish' number fields.
-		// error catching
-		// -- start has to be less than finish
-		if( headingInputValue.start > headingInputValue.finish ) {
-			return console.error('ERROR: heading start level cannot be greater than finish level' );
-		}
+		// get the heading range from options
+		setHeadingRange = (headingInputValue) => {
+			// the headingInputValue is an object with 'start' and 'finish' number fields.
+			// error catching
+			// -- start has to be less than finish
+			if (headingInputValue.start > headingInputValue.finish) {
+				return console.error('ERROR: heading start level cannot be greater than finish level');
+			}
 
-		// -- start and finish need to be between 1-6 incl.
-		if( ( headingInputValue.start  < 1 ) || ( headingInputValue.finish > 6 ) ) {
-			return console.error('ERROR: heading levels need to be between 1-6' );
-		}
+			// -- start and finish need to be between 1-6 incl.
+			if ((headingInputValue.start < 1) || (headingInputValue.finish > 6)) {
+				return console.error('ERROR: heading levels need to be between 1-6');
+			}
 
-		// set the range (literal as 'Hm-n')
-		let output = `${ headingInputValue.start }-${ headingInputValue.finish }`;
-		return output;
-	},
+			// set the range (literal as 'Hm-n')
+			let output = `${headingInputValue.start}-${headingInputValue.finish}`;
+			return output;
+		},
 
-	// save as constant
-	optionsLevelRange = setHeadingRange( optionsLevel );
-
+		// save as constant
+		optionsLevelRange = setHeadingRange(optionsLevel);
 
 	//
 	// MARK: - check if the document starts with the signifier
 	//
 
-	// get the `@autoHeader:` data
-	hook.beforeEach( function( content ) {
-		// check if beginning with the plugin key		
+	// get the heading number settings in `@autoHeader:` or `<!-- autoHeader: -->`.
+	hook.beforeEach(function (content) {
+		// check if beginning with the plugin key        
 		let separator = optionsSeparator;
 		if (optionsSeparator === '.' || optionsSeparator === ')') {
-			separator = '\\'+optionsSeparator;
+			separator = '\\' + optionsSeparator;
 		}
 		const commentRegex = new RegExp(
-			'<!--\\s*autoHeader\\s*:\\s*(([\\w\\d]*'+separator+'?)+)\\s*-->');
-		for (const line of content.split( "\n" )){
-			console.debug(line)
-			if (! line.startsWith("<!--")){
+			'<!--\\s*autoHeader\\s*:\\s*(([\\w\\d]*' + separator + '?)+)\\s*-->');
+		for (const line of content.split("\n")) {
+			if (!line.startsWith("<!--")) {
 				break
 			}
 			let match = line.trim().match(commentRegex)
@@ -191,7 +173,7 @@ function autoHeaders( hook, vm ) {
 				continue
 			}
 			console.debug(match[1])
-			if (match[1] === "off"){
+			if (match[1] === "off") {
 				getHeadingNumber = null
 				return
 			}
@@ -201,32 +183,32 @@ function autoHeaders( hook, vm ) {
 			}
 		}
 
-		if( getHeadingNumber === null && content.startsWith("@autoHeader:") ) {
+		if (getHeadingNumber === null && content.startsWith("@autoHeader:")) {
 			// get the first line of data
-			const getFirstLine = content.split( "\n" )[0];
+			const getFirstLine = content.split("\n")[0];
 			// get everything after the `:`
 			// if not match, getHeadingNumber is undefined (!getHeadingNumber is true)
-			getHeadingNumber = getFirstLine.split( ":" )[1];
-			if(!getHeadingNumber || getHeadingNumber === ''){
+			getHeadingNumber = getFirstLine.split(":")[1];
+			if (!getHeadingNumber || getHeadingNumber === '') {
 				getHeadingNumber = null
 			}
 			else {
 				getHeadingNumber = getHeadingNumber.trim()
 			}
-			var cleanedContent = content.replace( getFirstLine, '' );
+			// remove the line containing "@autoHeader" mark.
+			var cleanedContent = content.replace(getFirstLine, '');
 		}
 
 		// there is no data to continue
-		if(getHeadingNumber !== null) {
+		if (getHeadingNumber !== null) {
 			// make an array from the separator
 			// map the Strings to Int
-			getHeadingNumber = getHeadingNumber.split( optionsSeparator )
-                                               .map(x => parseInt(x));
+			getHeadingNumber = getHeadingNumber.split(optionsSeparator)
+				.map(x => parseInt(x));
 
-			// don't work with too many items in the array
-			if( getHeadingNumber.length > 6 ) {
-				// set the headerNumber to null
-				getHeadingNumber = getHeadingNumber.slice(0,6);
+			if (getHeadingNumber.length > 6) {
+				// tolerate with exceeding items in the heading number array
+				getHeadingNumber = getHeadingNumber.slice(0, 6);
 			} else if (getHeadingNumber.length < 6) {
 				// padding to length of 6.
 				// padding with 1 instead of 0, since we will minus 1 before formatting
@@ -234,9 +216,7 @@ function autoHeaders( hook, vm ) {
 					new Array(6 - getHeadingNumber.length).fill(1)
 				)
 			}
-			// remove the line
-			if (cleanedContent){
-				// return the cleaned content
+			if (cleanedContent) { // return the cleaned content
 				return cleanedContent;
 			}
 		}
@@ -246,191 +226,131 @@ function autoHeaders( hook, vm ) {
 		}
 	});
 
-
-
 	//
 	// MARK: - add the heading numbers
 	//
-
-	hook.doneEach( function() {
-
+	hook.doneEach(function () {
 		//
 		// 1. scope checking
 		//
-
 		// set the scope of the auto numbering
-		const contentScope	= document.querySelector( optionsScope );
+		const contentScope = document.querySelector(optionsScope);
 
 		// if scope doesn't exist and we are debugging
-		if( !contentScope && optionsDebug ) {
-
-			// log the error
-			return console.error(
-				'ERROR: the "scope" entry is not valid'
-			);
-
+		if (!contentScope && optionsDebug) {
+			return console.error('ERROR: the "scope" entry is not valid');
 		}
-
-
 
 		//
 		// 2. do we have the headers array
 		//
+		if (getHeadingNumber === null) {
+			if (optionsDebug) {
+				console.info('INFO: the "start" number is empty or null, skip numbering.');
+			}
+			return
+		}
 
-		if( getHeadingNumber === null ) {
+		// 3. validate the array is all numeric
+		if (getHeadingNumber.every(isNaN)) {
+			if (optionsDebug) {
+				console.error('ERROR: the values provided are not numeric');
+			}
+			return
+		}
 
-			// log the error
-			return optionsDebug ? console.error(
-				'ERROR: the "start" number is empty or null'
-			) : '';
+		// get the headings into array
+		const contentHeaders = contentScope.querySelectorAll(
+			'h1, h2, h3, h4, h5, h6');
 
-		} else {
+		// 4. check if the array items are positive numbers
+		const positiveNumber = (element) => (element >= 0);
+		if (!getHeadingNumber.every(positiveNumber)) {
+			if (optionsDebug) {
+				console.error('ERROR: the values are not positive integers')
+			}
+			return
+		}
 
-			// 2. validate the array is all numeric
-			if( getHeadingNumber.every( isNaN ) ) {
+		// 5. build the heading numbers
+		// generate the constants
+		// -- minus 1 since we add immediately in the loop
+		const startingNumbers = [
+			0,                       // null
+			getHeadingNumber[0] - 1, // h1
+			getHeadingNumber[1] - 1, // h2
+			getHeadingNumber[2] - 1, // h3
+			getHeadingNumber[3] - 1, // h4
+			getHeadingNumber[4] - 1, // h5
+			getHeadingNumber[5] - 1, // h6
+		];
 
-				// log the error
-				return optionsDebug ? console.error(
-					'ERROR: the values provided are not numeric'
-				) : '';
-
-			} else {
-
-				//
-				// validated constants
-				//
-
-				let validHeadingNumber	= '';
-
-				// get the headings into array
-				const contentHeaders = contentScope.querySelectorAll(
-					'h1, h2, h3, h4, h5, h6'
-				),
-
-				// check if the array items are positive numbers
-				positiveNumber = ( element ) => ( element >= 0 );
-
-				// 3. are the numbers all positive
-				if( getHeadingNumber.every( positiveNumber ) ) {
-
-					// 4. build the functionality
-
-
-					// generate the constants
-					// -- minus 1 since we add immediately in the loop
-					const startingNumbers = [
-						0,                       // null
-						getHeadingNumber[ 0 ] - 1, // h1
-						getHeadingNumber[ 1 ] - 1, // h2
-						getHeadingNumber[ 2 ] - 1, // h3
-						getHeadingNumber[ 3 ] - 1, // h4
-						getHeadingNumber[ 4 ] - 1, // h5
-						getHeadingNumber[ 5 ] - 1, // h6
-					];
-
-					// track the first run
-					let firstRun = [
-						true,	// null
-						true, 	// h1 run yet
-						true,	// h2 run yet
-						true,	// h3 run yet
-						true,	// h4 run yet
-						true,	// h5 run yet
-						true	// h6 run yet
-					];
-
-					// loop through all the elements inside scope
-					for( var contentItem in contentHeaders ) {
-
-
-						// this element from item number
-						var element = (
-							contentHeaders[ contentItem ]
-						),
-						numberText	= '';
-
-						// limit the heading tag number in search
-						const headingRegex = new RegExp(
-							`^H([${ optionsLevelRange }])$`  // "^H([1-6])$"
-						);
-
-						// does the element match a heading regex
-						// -- return to beginning of loop
-						if( !element || !element.tagName ) {
-							continue;
-						}
-						match = element.tagName.match( headingRegex )
-						if (match === null || match[1] === ''){ // not match
-							continue
-						}
-						// return the heading level number
-						var elementLevel = parseInt(match[1]);
-
-						// add `1` to the array numbers
-						startingNumbers[ elementLevel ]++;
-
-
-						// reset all level below except for the first run
-						// only running on the given level range 
-					    if( !firstRun[ elementLevel ] && (elementLevel>=optionsLevel.start) ) {
-
-							// callback
-							resetBelowLevels( elementLevel );
-
-						}
-
-						// set the first run to false
-						firstRun[ elementLevel ] = false;
-
-						// loop through the headings
-						for(
-							var levelNumber = optionsLevel.start;
-								levelNumber <= 6;
-								levelNumber++
-						) {
-
-							// if the loop number
-							// is less than the element number
-							// then generate the numbering text
-							if( levelNumber <= elementLevel ) {
-								numberText += startingNumbers[ levelNumber ] + optionsSeparator
-
-							} else {
-
-								// go back to top
-								continue;
-
-							}
-
-						}
-
-						// add the number outside the heading
-						// -- keep the anchor links :)
-						element.innerHTML =  numberText + ' ' + element.innerHTML.replace(/^[0-9\.\s]+/, '' );
-
-					}
-
-					// callback function
-					function resetBelowLevels( currentLevel ) {
-
-						// currentLevel is string
-						// convert it to number
-						for( let i = +currentLevel + 1; i <= 6; i++ ) {
-							startingNumbers[ i ] = 0;
-						}
-					}
-
-				} else {
-
-					// log the error
-					return optionsDebug ? console.error(
-						'ERROR: the values are not positive integers'
-					) : '';
-
-				}
+		function resetBelowLevels(currentLevel) {
+			// if currentLevel is string, convert it to number
+			// lower level head number set to `0`, so next we meet a lower level 
+			// head, it will be increment to `1`.
+			for (let i = +currentLevel + 1; i <= 6; i++) {
+				startingNumbers[i] = 0;
 			}
 		}
-	});
+
+		// track the first run
+		let firstRun = [
+			true,    // null
+			true,    // h1 run yet
+			true,    // h2 run yet
+			true,    // h3 run yet
+			true,    // h4 run yet
+			true,    // h5 run yet
+			true     // h6 run yet
+		];
+
+		// loop through all the elements inside scope
+		for (var contentItem in contentHeaders) {
+			// this element from item number
+			var element = (contentHeaders[contentItem]),
+				numberText = '';
+
+			// limit the heading tag number in search
+			const headingRegex = new RegExp(
+				`^H([${optionsLevelRange}])$`  // "^H([1-6])$"
+			);
+
+			// does the element match a heading regex
+			// -- return to beginning of loop
+			if (!element || !element.tagName) {
+				continue;
+			}
+			let match = element.tagName.match(headingRegex)
+			if (match === null || match[1] === '') { // not match
+				continue
+			}
+			// return the heading level number
+			let elementLevel = parseInt(match[1]);
+
+			// increment the heading level number by `1`
+			startingNumbers[elementLevel]++;
+
+			// reset all level below except for the first run
+			// only running on the given level range 
+			if (!firstRun[elementLevel] && (elementLevel >= optionsLevel.start)) {
+				resetBelowLevels(elementLevel);
+			}
+			// set the first run to false
+			firstRun[elementLevel] = false;
+
+			// loop through the headings
+			// only levels inside the configured range will be displayed in the header
+			for (let level = optionsLevel.start; level <= elementLevel; level++) {
+				numberText += startingNumbers[level] + optionsSeparator
+			}
+
+			// add the number outside the heading
+			// -- keep the anchor links :)
+			element.innerHTML = numberText + ' ' + element.innerHTML.replace(/^[0-9\.\s]+/, '');
+		}
+	}
+	);
 }
 
 

--- a/dist/docsify-autoHeaders.js
+++ b/dist/docsify-autoHeaders.js
@@ -77,6 +77,23 @@ function getAutoHeadersOptions( autoHeaderOptions ) {
 		autoHeaderOptions.levels ?
 			autoHeaderOptions.levels : 6
 	);
+	if (typeof levels === "string"){
+		levels = parseInt(levels)
+	}
+	if (typeof levels === "number" ){
+		levels = {
+			start: 1,
+			finish: levels
+		}
+	}
+	else if (typeof levels === "object" ) {
+		if (typeof levels.start === "string") {
+			levels.start = parseInt(levels.start)
+		}
+		if (typeof levels.finish === "string") {
+			levels.finish = parseInt(levels.finish)
+		}
+	}
 
 	let scope = (
 		autoHeaderOptions.scope ?
@@ -122,7 +139,6 @@ function autoHeaders( hook, vm ) {
 	const getAutoHeadersOptionsArray = getAutoHeadersOptions(
 		autoHeaderOptions
 	),
-
 	// create new variables
 	optionsSeparator = getAutoHeadersOptionsArray[ 0 ],
 	optionsLevel     = getAutoHeadersOptionsArray[ 1 ],
@@ -131,45 +147,25 @@ function autoHeaders( hook, vm ) {
 
 	// get the heading range from options
 	setHeadingRange = ( headingInputValue ) => {
-
-		// variables
-		let output = '';
-
-		// 1. check if is a string
-		if(
-			typeof optionsLevel === 'string'
-		) {
-
-			// set it as H1 to
-			output = `H1-${ headingInputValue }`;
-
-		// 2. check if is object and not null
-		} else if(
-			typeof optionsLevel === 'object' &&
-			optionsLevel !== null
-		) {
-
-			// error catching
-
-			// -- start has to be less than finish
-			if( headingInputValue.start > headingInputValue.finish ) {
-				return console.log( 'ERROR: heading start level cannot be greater than finish level' );
-			}
-
-			// -- start and finish need to be between 1-6 incl.
-			if(
-				( headingInputValue.start  < 1 ) ||
-				( headingInputValue.start  > 6 ) ||
-				( headingInputValue.finish < 1 ) ||
-				( headingInputValue.finish > 6 )
-			) {
-				return console.log( 'ERROR: heading levels need to be between 1-6' );
-			}
-
-			// set the range
-			output = `H${ headingInputValue.start }-${ headingInputValue.finish }`;
+		// the headingInputValue is an object with 'start' and 'finish' number fields.
+		// error catching
+		// -- start has to be less than finish
+		if( headingInputValue.start > headingInputValue.finish ) {
+			return console.log( 'ERROR: heading start level cannot be greater than finish level' );
 		}
 
+		// -- start and finish need to be between 1-6 incl.
+		if(
+			( headingInputValue.start  < 1 ) ||
+			//( headingInputValue.start  > 6 ) ||
+			//( headingInputValue.finish < 1 ) ||
+			( headingInputValue.finish > 6 )
+		) {
+			return console.log( 'ERROR: heading levels need to be between 1-6' );
+		}
+
+		// set the range (literal as 'Hm-n')
+		let output = `${ headingInputValue.start }-${ headingInputValue.finish }`;
 		return output;
 	},
 
@@ -212,7 +208,7 @@ function autoHeaders( hook, vm ) {
 				// make an array from the separator
 				getHeadingNumber = getHeadingNumber.split( optionsSeparator );
 
-				// dont work with too many items in the array
+				// don't work with too many items in the array
 				if( getHeadingNumber.length > 6 ) {
 
 					// set the headerNumber to null
@@ -238,8 +234,8 @@ function autoHeaders( hook, vm ) {
 
 		} else {
 
-			// set the headerNumber to null
-			getHeadingNumber = null;
+			// set the headerNumber to default 1.1.1.1.1.1
+			getHeadingNumber = new Array(6).fill(1);
 		}
 	});
 
@@ -258,8 +254,7 @@ function autoHeaders( hook, vm ) {
 		// set the scope of the auto numbering
 		const contentScope	= document.querySelector( optionsScope );
 
-		// if scope doesnt exist
-		// and we are dubugging
+		// if scope doesn't exist and we are debugging
 		if( !contentScope && optionsDebug ) {
 
 			// log the error
@@ -370,7 +365,8 @@ function autoHeaders( hook, vm ) {
 
 
 						// reset all level below except for the first run
-					    if( !firstRun[ elementLevel ] ) {
+						// only running on the given level range 
+					    if( !firstRun[ elementLevel ] && (elementLevel>=optionsLevel.start) ) {
 
 							// callback
 							resetBelowLevels( elementLevel );
@@ -382,7 +378,7 @@ function autoHeaders( hook, vm ) {
 
 						// loop through the headings
 						for(
-							var levelNumber = 1;
+							var levelNumber = optionsLevel.start;
 								levelNumber <= 6;
 								levelNumber++
 						) {


### PR DESCRIPTION
# Pull request

## Description

<!--
    >> Please detail what this Pull Request entails
    - what did you change?
    - what was fixed?
    - anything major deprecated or added
-->

- refactor(46d56f0): format the code and restructure the control flow.
- fix(5d086fd): default configuration and other minor fixes.
    1. set default configuration value in code (fix wrong default value
       `'main'` for scope, right one should be `'#main'`);
    1. tolerate invalid heading number configuration that exceed 6 heading
       numbers.
    1. padding missing heading number with `1` instead of `0`, conforming to
       the header numbering rules.
    1. update the legacy usage of `RegExp.$1`.

- feat(8d9c1fd): HTML comment for setting `autoHeaders` in docs
    1. Using HTML comment "`<!-- autoHeaders:off -->`" to disable auto header
       numbering of current document;
    2. using "`<!-- autoHeaders: 1.1.1.1.1.1 -->`" to set the start heading
       number of current document.

- feat(734d804): auto numbering on specified head levels
    1. auto numbering is enabled without `@autoHeaders` mark;
    2. only the specified range of levels will be used for calculating and
       displaying head numbers (ignore out of range levels).

       - before: if we skip H1 header, the H2 will be prefixed with "`H1.H2.`",
       - after: the H2 will be prefixed with "`H2.`" (expected).

## Issues closed

None.

## Did you test it locally?

- [x] I tested it on a local environment and it works

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own document
- [ ] I updated the change log file linking to the relevant sections
- [x] My changes generate no new warnings
- [x] I have checked corrected any misspellings
